### PR TITLE
Add Fichas & Encaminhamentos modules, Dashboard API and redesigned frontend dashboard/home

### DIFF
--- a/backend/postman/ONG.postman_collection.json
+++ b/backend/postman/ONG.postman_collection.json
@@ -147,12 +147,186 @@
           }
         }
       ]
+    },
+    {
+      "name": "Fichas",
+      "item": [
+        {
+          "name": "Criar",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 201/200', function () { pm.expect(pm.response.code).to.be.oneOf([200,201]); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('fichaId', json.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"estudanteId\": \"11111111-1111-1111-1111-111111111111\",\n  \"empresaId\": \"22222222-2222-2222-2222-222222222222\",\n  \"dataRegistro\": \"2026-04-10\",\n  \"status\": \"ativo\",\n  \"descricao\": \"Acompanhamento inicial para vaga administrativa.\",\n  \"proximosPassos\": \"Agendar visita tecnica na empresa.\"\n}"
+            },
+            "url": "{{baseUrl}}/fichas"
+          }
+        },
+        {
+          "name": "Listar",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Retorna array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/fichas"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Encaminhamentos",
+      "item": [
+        {
+          "name": "Criar",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 201/200', function () { pm.expect(pm.response.code).to.be.oneOf([200,201]); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('encaminhamentoId', json.id);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"estudanteId\": \"11111111-1111-1111-1111-111111111111\",\n  \"empresaId\": \"22222222-2222-2222-2222-222222222222\",\n  \"fichaAcompanhamentoId\": \"{{fichaId}}\",\n  \"dataEncaminhamento\": \"2026-04-12\",\n  \"status\": \"ativo\",\n  \"observacoes\": \"Encaminhamento para entrevista inicial.\"\n}"
+            },
+            "url": "{{baseUrl}}/encaminhamentos"
+          }
+        },
+        {
+          "name": "Listar",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Retorna array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/encaminhamentos"
+          }
+        },
+        {
+          "name": "Atualizar status",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Status desligado', function () { pm.expect(pm.response.json().status).to.eql('desligado'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"desligado\"\n}"
+            },
+            "url": "{{baseUrl}}/encaminhamentos/{{encaminhamentoId}}/status"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Dashboard",
+      "item": [
+        {
+          "name": "Visao geral",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('Possui resumo', function () { pm.expect(json).to.have.property('resumo'); });",
+                  "pm.test('Resumo contem fichas e encaminhamentos', function () {",
+                  "  pm.expect(json.resumo).to.have.property('fichasAcompanhamento');",
+                  "  pm.expect(json.resumo).to.have.property('encaminhamentosAtivos');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/dashboard"
+          }
+        }
+      ]
     }
   ],
   "variable": [
     {
       "key": "baseUrl",
       "value": "http://localhost:3001/api"
+    },
+    {
+      "key": "fichaId",
+      "value": ""
+    },
+    {
+      "key": "encaminhamentoId",
+      "value": ""
     }
   ]
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,9 @@ import { EmpresasModule } from './modules/empresas/empresas.module';
 import { FuncionariosModule } from './modules/funcionarios/funcionarios.module';
 import { AvaliacoesModule } from './modules/avaliacoes/avaliacoes.module';
 import { RelacionamentosModule } from './modules/relacionamentos/relacionamentos.module';
+import { FichasModule } from './modules/fichas/fichas.module';
+import { EncaminhamentosModule } from './modules/encaminhamentos/encaminhamentos.module';
+import { DashboardModule } from './modules/dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -21,6 +24,9 @@ import { RelacionamentosModule } from './modules/relacionamentos/relacionamentos
     FuncionariosModule,
     AvaliacoesModule,
     RelacionamentosModule,
+    FichasModule,
+    EncaminhamentosModule,
+    DashboardModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/migrations/1760000003000-AddFichasEEncaminhamentos.ts
+++ b/backend/src/migrations/1760000003000-AddFichasEEncaminhamentos.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFichasEEncaminhamentos1760000003000 implements MigrationInterface {
+  name = 'AddFichasEEncaminhamentos1760000003000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "fichas_acompanhamento" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "estudanteId" uuid NOT NULL,
+        "empresaId" uuid,
+        "dataRegistro" date NOT NULL,
+        "status" character varying(20) NOT NULL DEFAULT 'ativo',
+        "descricao" text NOT NULL,
+        "proximosPassos" text,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_fichas_acompanhamento_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_fichas_estudante" FOREIGN KEY ("estudanteId") REFERENCES "estudantes"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_fichas_empresa" FOREIGN KEY ("empresaId") REFERENCES "empresas"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "encaminhamentos" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "estudanteId" uuid NOT NULL,
+        "empresaId" uuid NOT NULL,
+        "fichaAcompanhamentoId" uuid,
+        "dataEncaminhamento" date NOT NULL,
+        "status" character varying(20) NOT NULL DEFAULT 'ativo',
+        "observacoes" text,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_encaminhamentos_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_encaminhamentos_estudante" FOREIGN KEY ("estudanteId") REFERENCES "estudantes"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_encaminhamentos_empresa" FOREIGN KEY ("empresaId") REFERENCES "empresas"("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_encaminhamentos_ficha" FOREIGN KEY ("fichaAcompanhamentoId") REFERENCES "fichas_acompanhamento"("id") ON DELETE SET NULL ON UPDATE NO ACTION
+      );
+    `);
+
+    await queryRunner.query('CREATE INDEX "IDX_fichas_estudante" ON "fichas_acompanhamento" ("estudanteId");');
+    await queryRunner.query('CREATE INDEX "IDX_fichas_empresa" ON "fichas_acompanhamento" ("empresaId");');
+    await queryRunner.query('CREATE INDEX "IDX_encaminhamentos_estudante" ON "encaminhamentos" ("estudanteId");');
+    await queryRunner.query('CREATE INDEX "IDX_encaminhamentos_empresa" ON "encaminhamentos" ("empresaId");');
+    await queryRunner.query('CREATE INDEX "IDX_encaminhamentos_status" ON "encaminhamentos" ("status");');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_encaminhamentos_status";');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_encaminhamentos_empresa";');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_encaminhamentos_estudante";');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_fichas_empresa";');
+    await queryRunner.query('DROP INDEX IF EXISTS "IDX_fichas_estudante";');
+    await queryRunner.query('DROP TABLE IF EXISTS "encaminhamentos";');
+    await queryRunner.query('DROP TABLE IF EXISTS "fichas_acompanhamento";');
+  }
+}

--- a/backend/src/modules/dashboard/dashboard.controller.ts
+++ b/backend/src/modules/dashboard/dashboard.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly service: DashboardService) {}
+
+  @Get()
+  getOverview() {
+    return this.service.getOverview();
+  }
+}

--- a/backend/src/modules/dashboard/dashboard.module.ts
+++ b/backend/src/modules/dashboard/dashboard.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { Estudante } from '../estudantes/estudante.entity';
+import { Empresa } from '../empresas/empresa.entity';
+import { Funcionario } from '../funcionarios/funcionario.entity';
+import { Avaliacao } from '../avaliacoes/avaliacao.entity';
+import { FichaAcompanhamento } from '../fichas/ficha-acompanhamento.entity';
+import { Encaminhamento } from '../encaminhamentos/encaminhamento.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Estudante,
+      Empresa,
+      Funcionario,
+      Avaliacao,
+      FichaAcompanhamento,
+      Encaminhamento,
+    ]),
+  ],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/backend/src/modules/dashboard/dashboard.service.ts
+++ b/backend/src/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Estudante } from '../estudantes/estudante.entity';
+import { Empresa } from '../empresas/empresa.entity';
+import { Funcionario } from '../funcionarios/funcionario.entity';
+import { Avaliacao } from '../avaliacoes/avaliacao.entity';
+import { FichaAcompanhamento } from '../fichas/ficha-acompanhamento.entity';
+import { Encaminhamento } from '../encaminhamentos/encaminhamento.entity';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(Estudante) private readonly estudantesRepo: Repository<Estudante>,
+    @InjectRepository(Empresa) private readonly empresasRepo: Repository<Empresa>,
+    @InjectRepository(Funcionario) private readonly funcionariosRepo: Repository<Funcionario>,
+    @InjectRepository(Avaliacao) private readonly avaliacoesRepo: Repository<Avaliacao>,
+    @InjectRepository(FichaAcompanhamento) private readonly fichasRepo: Repository<FichaAcompanhamento>,
+    @InjectRepository(Encaminhamento) private readonly encaminhamentosRepo: Repository<Encaminhamento>,
+  ) {}
+
+  async getOverview() {
+    const [
+      estudantes,
+      empresas,
+      funcionarios,
+      avaliacoes,
+      fichasAcompanhamento,
+      encaminhamentosAtivos,
+      encaminhamentosDesligados,
+      encaminhamentosRecentes,
+      fichasRecentes,
+    ] = await Promise.all([
+      this.estudantesRepo.count(),
+      this.empresasRepo.count(),
+      this.funcionariosRepo.count(),
+      this.avaliacoesRepo.count(),
+      this.fichasRepo.count(),
+      this.encaminhamentosRepo.count({ where: { status: 'ativo' } }),
+      this.encaminhamentosRepo.count({ where: { status: 'desligado' } }),
+      this.encaminhamentosRepo.find({ order: { createdAt: 'DESC' }, take: 5 }),
+      this.fichasRepo.find({ order: { createdAt: 'DESC' }, take: 5 }),
+    ]);
+
+    return {
+      resumo: {
+        estudantes,
+        empresas,
+        funcionarios,
+        avaliacoes,
+        fichasAcompanhamento,
+        encaminhamentosAtivos,
+        encaminhamentosDesligados,
+      },
+      encaminhamentosRecentes,
+      fichasRecentes,
+    };
+  }
+}

--- a/backend/src/modules/encaminhamentos/dto.ts
+++ b/backend/src/modules/encaminhamentos/dto.ts
@@ -1,0 +1,25 @@
+import { IsDateString, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+const STATUS_VALUES = ['ativo', 'desligado'] as const;
+
+export class CreateEncaminhamentoDto {
+  @IsString() @IsNotEmpty() estudanteId: string;
+  @IsString() @IsNotEmpty() empresaId: string;
+  @IsOptional() @IsString() fichaAcompanhamentoId?: string;
+  @IsDateString() dataEncaminhamento: string;
+  @IsOptional() @IsString() @IsIn(STATUS_VALUES) status?: string;
+  @IsOptional() @IsString() observacoes?: string;
+}
+
+export class UpdateEncaminhamentoDto {
+  @IsOptional() @IsString() estudanteId?: string;
+  @IsOptional() @IsString() empresaId?: string;
+  @IsOptional() @IsString() fichaAcompanhamentoId?: string;
+  @IsOptional() @IsDateString() dataEncaminhamento?: string;
+  @IsOptional() @IsString() @IsIn(STATUS_VALUES) status?: string;
+  @IsOptional() @IsString() observacoes?: string;
+}
+
+export class UpdateEncaminhamentoStatusDto {
+  @IsString() @IsIn(STATUS_VALUES) status: string;
+}

--- a/backend/src/modules/encaminhamentos/encaminhamento.entity.ts
+++ b/backend/src/modules/encaminhamentos/encaminhamento.entity.ts
@@ -1,0 +1,46 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Empresa } from '../empresas/empresa.entity';
+import { Estudante } from '../estudantes/estudante.entity';
+import { FichaAcompanhamento } from '../fichas/ficha-acompanhamento.entity';
+
+@Entity('encaminhamentos')
+export class Encaminhamento {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  estudanteId: string;
+
+  @Column({ type: 'uuid' })
+  empresaId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  fichaAcompanhamentoId?: string | null;
+
+  @ManyToOne(() => Estudante, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'estudanteId' })
+  estudante: Estudante;
+
+  @ManyToOne(() => Empresa, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'empresaId' })
+  empresa: Empresa;
+
+  @ManyToOne(() => FichaAcompanhamento, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'fichaAcompanhamentoId' })
+  fichaAcompanhamento?: FichaAcompanhamento | null;
+
+  @Column({ type: 'date' })
+  dataEncaminhamento: string;
+
+  @Column({ length: 20, default: 'ativo' })
+  status: string;
+
+  @Column({ type: 'text', nullable: true })
+  observacoes?: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/modules/encaminhamentos/encaminhamentos.controller.ts
+++ b/backend/src/modules/encaminhamentos/encaminhamentos.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Param, Patch, Post, Put } from '@nestjs/common';
+import { EncaminhamentosService } from './encaminhamentos.service';
+import { CreateEncaminhamentoDto, UpdateEncaminhamentoDto, UpdateEncaminhamentoStatusDto } from './dto';
+
+@Controller('encaminhamentos')
+export class EncaminhamentosController {
+  constructor(private readonly service: EncaminhamentosService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateEncaminhamentoDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateEncaminhamentoDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Patch(':id/status')
+  updateStatus(@Param('id') id: string, @Body() dto: UpdateEncaminhamentoStatusDto) {
+    return this.service.updateStatus(id, dto.status);
+  }
+}

--- a/backend/src/modules/encaminhamentos/encaminhamentos.module.ts
+++ b/backend/src/modules/encaminhamentos/encaminhamentos.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Encaminhamento } from './encaminhamento.entity';
+import { EncaminhamentosController } from './encaminhamentos.controller';
+import { EncaminhamentosService } from './encaminhamentos.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Encaminhamento])],
+  controllers: [EncaminhamentosController],
+  providers: [EncaminhamentosService],
+  exports: [TypeOrmModule],
+})
+export class EncaminhamentosModule {}

--- a/backend/src/modules/encaminhamentos/encaminhamentos.service.ts
+++ b/backend/src/modules/encaminhamentos/encaminhamentos.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Encaminhamento } from './encaminhamento.entity';
+import { CreateEncaminhamentoDto, UpdateEncaminhamentoDto } from './dto';
+
+@Injectable()
+export class EncaminhamentosService {
+  constructor(
+    @InjectRepository(Encaminhamento) private readonly repo: Repository<Encaminhamento>,
+  ) {}
+
+  list() {
+    return this.repo.find({ order: { createdAt: 'DESC' } });
+  }
+
+  async get(id: string) {
+    const encaminhamento = await this.repo.findOne({ where: { id } });
+    if (!encaminhamento) {
+      throw new NotFoundException('Encaminhamento nao encontrado');
+    }
+    return encaminhamento;
+  }
+
+  create(dto: CreateEncaminhamentoDto) {
+    return this.repo.save(this.repo.create(dto));
+  }
+
+  async update(id: string, dto: UpdateEncaminhamentoDto) {
+    const encaminhamento = await this.get(id);
+    this.repo.merge(encaminhamento, dto);
+    return this.repo.save(encaminhamento);
+  }
+
+  async updateStatus(id: string, status: string) {
+    const encaminhamento = await this.get(id);
+    encaminhamento.status = status;
+    return this.repo.save(encaminhamento);
+  }
+}

--- a/backend/src/modules/fichas/dto.ts
+++ b/backend/src/modules/fichas/dto.ts
@@ -1,0 +1,21 @@
+import { IsDateString, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+const STATUS_VALUES = ['ativo', 'desligado'] as const;
+
+export class CreateFichaAcompanhamentoDto {
+  @IsString() @IsNotEmpty() estudanteId: string;
+  @IsOptional() @IsString() empresaId?: string;
+  @IsDateString() dataRegistro: string;
+  @IsOptional() @IsString() @IsIn(STATUS_VALUES) status?: string;
+  @IsString() @IsNotEmpty() descricao: string;
+  @IsOptional() @IsString() proximosPassos?: string;
+}
+
+export class UpdateFichaAcompanhamentoDto {
+  @IsOptional() @IsString() estudanteId?: string;
+  @IsOptional() @IsString() empresaId?: string;
+  @IsOptional() @IsDateString() dataRegistro?: string;
+  @IsOptional() @IsString() @IsIn(STATUS_VALUES) status?: string;
+  @IsOptional() @IsString() descricao?: string;
+  @IsOptional() @IsString() proximosPassos?: string;
+}

--- a/backend/src/modules/fichas/ficha-acompanhamento.entity.ts
+++ b/backend/src/modules/fichas/ficha-acompanhamento.entity.ts
@@ -1,0 +1,41 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Estudante } from '../estudantes/estudante.entity';
+import { Empresa } from '../empresas/empresa.entity';
+
+@Entity('fichas_acompanhamento')
+export class FichaAcompanhamento {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  estudanteId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  empresaId?: string | null;
+
+  @ManyToOne(() => Estudante, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'estudanteId' })
+  estudante: Estudante;
+
+  @ManyToOne(() => Empresa, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'empresaId' })
+  empresa?: Empresa | null;
+
+  @Column({ type: 'date' })
+  dataRegistro: string;
+
+  @Column({ length: 20, default: 'ativo' })
+  status: string;
+
+  @Column({ type: 'text' })
+  descricao: string;
+
+  @Column({ type: 'text', nullable: true })
+  proximosPassos?: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/modules/fichas/fichas.controller.ts
+++ b/backend/src/modules/fichas/fichas.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import { FichasService } from './fichas.service';
+import { CreateFichaAcompanhamentoDto, UpdateFichaAcompanhamentoDto } from './dto';
+
+@Controller('fichas')
+export class FichasController {
+  constructor(private readonly service: FichasService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateFichaAcompanhamentoDto) {
+    return this.service.create(dto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateFichaAcompanhamentoDto) {
+    return this.service.update(id, dto);
+  }
+}

--- a/backend/src/modules/fichas/fichas.module.ts
+++ b/backend/src/modules/fichas/fichas.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FichaAcompanhamento } from './ficha-acompanhamento.entity';
+import { FichasService } from './fichas.service';
+import { FichasController } from './fichas.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FichaAcompanhamento])],
+  providers: [FichasService],
+  controllers: [FichasController],
+  exports: [TypeOrmModule],
+})
+export class FichasModule {}

--- a/backend/src/modules/fichas/fichas.service.ts
+++ b/backend/src/modules/fichas/fichas.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FichaAcompanhamento } from './ficha-acompanhamento.entity';
+import { CreateFichaAcompanhamentoDto, UpdateFichaAcompanhamentoDto } from './dto';
+
+@Injectable()
+export class FichasService {
+  constructor(
+    @InjectRepository(FichaAcompanhamento) private readonly repo: Repository<FichaAcompanhamento>,
+  ) {}
+
+  list() {
+    return this.repo.find({ order: { createdAt: 'DESC' } });
+  }
+
+  async get(id: string) {
+    const ficha = await this.repo.findOne({ where: { id } });
+    if (!ficha) {
+      throw new NotFoundException('Ficha de acompanhamento nao encontrada');
+    }
+    return ficha;
+  }
+
+  create(dto: CreateFichaAcompanhamentoDto) {
+    return this.repo.save(this.repo.create(dto));
+  }
+
+  async update(id: string, dto: UpdateFichaAcompanhamentoDto) {
+    const ficha = await this.get(id);
+    this.repo.merge(ficha, dto);
+    return this.repo.save(ficha);
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import Login from './components/Login';
 import Dashboard from './components/Dashboard';
+import Home from './components/Home';
 import ListaEstudantes from './components/ListaEstudantes';
 import ListaAvaliacoes from './components/ListaAvaliacoes';
 import ListaEmpresas from './components/ListaEmpresas';
@@ -37,7 +38,8 @@ function App() {
           <Header user={user} onLogout={handleLogout} />
           <main className="main-content">
             <Routes>
-              <Route path="/" element={<Dashboard />} />
+              <Route path="/" element={<Home />} />
+              <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/cadastroAlunos" element={<ListaEstudantes />} />
               <Route path="/novo-estudante" element={<CadastroAlunos />} />
               <Route path="/editar-estudante/:id" element={<EditarEstudante />} />

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -1,522 +1,169 @@
-﻿/* ==============================
-   Dashboard Component Styles - Tema Azul
-================================*/
-
-.dashboard {
+.dashboard-v2 {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem 1.5rem;
+  padding: 2rem 1.5rem 3rem;
 }
 
-.dashboard-header {
-  margin-bottom: 2rem;
-  text-align: center;
+.dashboard-v2-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
 }
 
-.dashboard-header h1 {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: 0.5rem;
-  background: linear-gradient(135deg, #1e40af, #3b82f6);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.dashboard-header p {
-  color: var(--text-light);
-  font-size: 1.1rem;
+.dashboard-v2-tag {
   margin: 0;
-}
-
-/* ==============================
-   Stats Grid
-================================*/
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 3rem;
-}
-
-.stat-card {
-  background: var(--card-bg);
-  border-radius: 20px;
-  padding: 2rem;
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  box-shadow: var(--shadow-md);
-  transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
-  border: 2px solid transparent;
-}
-
-.stat-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, #1e40af, #3b82f6);
-}
-
-.stat-card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-lg);
-  border-color: rgba(59, 130, 246, 0.2);
-}
-
-.stat-card.blue::before {
-  background: linear-gradient(90deg, #1e40af, #3b82f6);
-}
-
-.stat-card.green::before {
-  background: linear-gradient(90deg, #059669, #10b981);
-}
-
-.stat-card.purple::before {
-  background: linear-gradient(90deg, #7c3aed, #8b5cf6);
-}
-
-.stat-card.orange::before {
-  background: linear-gradient(90deg, #ea580c, #f97316);
-}
-
-.stat-icon {
-  width: 56px;
-  height: 56px;
-  border-radius: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.95rem;
+  color: #1d4ed8;
   font-weight: 700;
-  letter-spacing: 0.06em;
-  color: #ffffff;
-  background: linear-gradient(135deg, #1e40af, #3b82f6);
-  box-shadow: var(--shadow-sm);
-}
-
-.stat-card.green .stat-icon {
-  background: linear-gradient(135deg, #047857, #10b981);
-}
-
-.stat-card.purple .stat-icon {
-  background: linear-gradient(135deg, #6d28d9, #8b5cf6);
-}
-
-.stat-card.orange .stat-icon {
-  background: linear-gradient(135deg, #c2410c, #f97316);
-}
-
-.stat-content {
-  flex: 1;
-}
-
-.stat-title {
-  font-size: 1rem;
-  color: var(--text-light);
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-}
-
-.stat-value {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: 0.25rem;
-}
-
-.stat-description {
-  font-size: 0.85rem;
-  color: var(--text-light);
-  margin-bottom: 0.5rem;
-}
-
-.stat-change {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.stat-change.positive {
-  color: #10b981;
-}
-
-.stat-change.negative {
-  color: #ef4444;
-}
-
-.change-icon {
+  text-transform: uppercase;
   font-size: 0.75rem;
 }
 
-/* ==============================
-   Dashboard Content
-================================*/
-.dashboard-content {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: 2rem;
+.dashboard-v2-header h1 {
+  margin: 0.4rem 0;
+  font-size: clamp(1.6rem, 3vw, 2.3rem);
 }
 
-.dashboard-section {
+.dashboard-v2-subtitle {
+  margin: 0;
+  color: var(--text-light);
+}
+
+.dashboard-v2-cta {
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #fff;
+  text-decoration: none;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.dashboard-v2-feedback {
   background: var(--card-bg);
-  border-radius: 20px;
-  padding: 2rem;
-  box-shadow: var(--shadow-md);
-  border: 2px solid transparent;
-  transition: all 0.3s ease;
+  padding: 1rem;
+  border-radius: 12px;
+  margin-bottom: 1rem;
 }
 
-.dashboard-section:hover {
-  border-color: rgba(59, 130, 246, 0.1);
+.dashboard-v2-feedback.error {
+  border: 1px solid #fca5a5;
+  color: #b91c1c;
 }
 
-.dashboard-section h2 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--text);
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 2px solid var(--background);
-  position: relative;
-}
-
-.dashboard-section h2::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 40px;
-  height: 2px;
-  background: linear-gradient(90deg, #1e40af, #3b82f6);
-}
-
-/* ==============================
-   Quick Actions
-================================*/
-.quick-actions-grid {
+.dashboard-v2-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
 
-.quick-action-card {
+.dash-card {
+  border-radius: 16px;
+  padding: 1rem;
+  background: var(--card-bg);
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.dash-card strong {
+  display: block;
+  margin: 0.35rem 0;
+  font-size: 1.8rem;
+}
+
+.dash-card small {
+  color: var(--text-light);
+}
+
+.dash-card.blue { border-top: 4px solid #2563eb; }
+.dash-card.green { border-top: 4px solid #059669; }
+.dash-card.orange { border-top: 4px solid #ea580c; }
+.dash-card.purple { border-top: 4px solid #7c3aed; }
+.dash-card.teal { border-top: 4px solid #0f766e; }
+.dash-card.red { border-top: 4px solid #dc2626; }
+
+.dashboard-v2-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.dash-panel {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-md);
+}
+
+.dash-panel h2 {
+  margin: 0 0 0.9rem;
+}
+
+.timeline-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.timeline-item {
+  background: var(--background);
+  border-radius: 12px;
+  padding: 0.8rem;
+}
+
+.timeline-item p {
+  margin: 0;
+  font-weight: 600;
+}
+
+.timeline-item span {
+  color: var(--text-light);
+  font-size: 0.85rem;
+}
+
+.quick-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.8rem;
+}
+
+.quick-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1.5rem;
-  border-radius: 16px;
+  gap: 0.8rem;
   text-decoration: none;
   color: inherit;
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
-  position: relative;
-  overflow: hidden;
+  background: var(--background);
+  border-radius: 12px;
+  padding: 0.9rem;
 }
 
-.quick-action-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.05), rgba(30, 64, 175, 0.02));
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.quick-action-card:hover::before {
-  opacity: 1;
-}
-
-.quick-action-card:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg);
-  border-color: rgba(59, 130, 246, 0.2);
-}
-
-.quick-action-card.blue {
-  background: linear-gradient(135deg, rgba(30, 64, 175, 0.1), rgba(59, 130, 246, 0.05));
-  border-color: rgba(30, 64, 175, 0.2);
-}
-
-.quick-action-card.green {
-  background: linear-gradient(135deg, rgba(5, 150, 105, 0.1), rgba(16, 185, 129, 0.05));
-  border-color: rgba(5, 150, 105, 0.2);
-}
-
-.quick-action-card.purple {
-  background: linear-gradient(135deg, rgba(124, 58, 237, 0.1), rgba(139, 92, 246, 0.05));
-  border-color: rgba(124, 58, 237, 0.2);
-}
-
-.quick-action-card.orange {
-  background: linear-gradient(135deg, rgba(234, 88, 12, 0.1), rgba(249, 115, 22, 0.05));
-  border-color: rgba(234, 88, 12, 0.2);
-}
-
-.quick-action-card.teal {
-  background: linear-gradient(135deg, rgba(15, 118, 110, 0.1), rgba(20, 184, 166, 0.05));
-  border-color: rgba(15, 118, 110, 0.25);
-}
-
-.action-icon {
-  font-size: 2.5rem;
-  opacity: 0.9;
-}
-
-.action-content {
-  flex: 1;
-}
-
-.action-content h3 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--text);
-  margin-bottom: 0.25rem;
-}
-
-.action-content p {
-  font-size: 0.9rem;
-  color: var(--text-light);
-  margin: 0;
-}
-
-.action-arrow {
-  color: var(--text-light);
-  transition: all 0.3s ease;
-}
-
-.quick-action-card:hover .action-arrow {
-  color: #3b82f6;
-  transform: translateX(4px);
-}
-
-/* ==============================
-   Resources
-================================*/
-.resources-grid {
+.quick-card span {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  place-items: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
 }
 
-.resource-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-  border-radius: 12px;
-  background: var(--background);
-  transition: all 0.3s ease;
-  border: 2px solid transparent;
-}
-
-.resource-card:hover {
-  background: rgba(59, 130, 246, 0.05);
-  border-color: rgba(59, 130, 246, 0.2);
-  transform: translateY(-2px);
-}
-
-.resource-icon {
-  font-size: 2rem;
-  opacity: 0.8;
-}
-
-.resource-content {
-  flex: 1;
-}
-
-.resource-content h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text);
-  margin-bottom: 0.25rem;
-}
-
-.resource-content p {
-  font-size: 0.85rem;
-  color: var(--text-light);
+.quick-card h3 {
   margin: 0;
-}
-
-.resource-btn {
-  background: none;
-  border: none;
-  color: var(--text-light);
-  cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 8px;
-  transition: all 0.3s ease;
-}
-
-.resource-btn:hover {
-  background: rgba(59, 130, 246, 0.1);
-  color: #3b82f6;
-}
-
-/* ==============================
-   Activities List
-================================*/
-.activities-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.activity-item {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-  border-radius: 12px;
-  background: var(--background);
-  transition: all 0.2s ease;
-  border: 2px solid transparent;
-}
-
-.activity-item:hover {
-  background: rgba(59, 130, 246, 0.05);
-  border-color: rgba(59, 130, 246, 0.1);
-}
-
-.activity-icon {
-  font-size: 1.25rem;
-  flex-shrink: 0;
-}
-
-.activity-content {
-  flex: 1;
-}
-
-.activity-action {
-  font-weight: 500;
-  color: var(--text);
-  font-size: 0.9rem;
-  margin-bottom: 0.25rem;
-}
-
-.activity-user {
-  font-size: 0.8rem;
-  color: var(--text-light);
-}
-
-.activity-time {
-  font-size: 0.8rem;
-  color: var(--text-light);
-  flex-shrink: 0;
-}
-
-/* Hard guard for light mode to avoid dark card leakage from legacy rules */
-html:not(.dark-theme) .stat-card,
-html:not(.dark-theme) .dashboard-section {
-  background: #ffffff !important;
-}
-
-html:not(.dark-theme) .resource-card,
-html:not(.dark-theme) .activity-item {
-  background: #f8fafc !important;
-}
-
-html:not(.dark-theme) .quick-action-card.blue {
-  background: linear-gradient(135deg, rgba(30, 64, 175, 0.1), rgba(59, 130, 246, 0.04)) !important;
-}
-
-html:not(.dark-theme) .quick-action-card.green {
-  background: linear-gradient(135deg, rgba(5, 150, 105, 0.1), rgba(16, 185, 129, 0.04)) !important;
-}
-
-html:not(.dark-theme) .quick-action-card.purple {
-  background: linear-gradient(135deg, rgba(124, 58, 237, 0.1), rgba(139, 92, 246, 0.04)) !important;
-}
-
-html:not(.dark-theme) .quick-action-card.orange {
-  background: linear-gradient(135deg, rgba(234, 88, 12, 0.1), rgba(249, 115, 22, 0.04)) !important;
-}
-
-html:not(.dark-theme) .quick-action-card.teal {
-  background: linear-gradient(135deg, rgba(15, 118, 110, 0.1), rgba(20, 184, 166, 0.04)) !important;
-}
-
-/* ==============================
-   Responsividade
-================================*/
-@media (max-width: 1024px) {
-  .dashboard-content {
-    grid-template-columns: 1fr;
-  }
+  font-size: 0.95rem;
 }
 
 @media (max-width: 768px) {
-  .dashboard {
-    padding: 1.5rem 1rem;
+  .dashboard-v2-header {
+    flex-direction: column;
   }
-  
-  .dashboard-header h1 {
-    font-size: 2rem;
-  }
-  
-  .stats-grid {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    margin-bottom: 2rem;
-  }
-  
-  .stat-card {
-    padding: 1.5rem;
-  }
-  
-  .stat-value {
-    font-size: 2rem;
-  }
-  
-  .quick-actions-grid {
-    grid-template-columns: 1fr;
-  }
-  
-  .dashboard-section {
-    padding: 1.5rem;
-  }
-  
-  .dashboard-section h2 {
-    font-size: 1.25rem;
+
+  .dashboard-v2-cta {
+    width: 100%;
+    text-align: center;
   }
 }
-
-@media (max-width: 480px) {
-  .dashboard {
-    padding: 1rem 0.75rem;
-  }
-  
-  .stat-card {
-    flex-direction: column;
-    text-align: center;
-    gap: 1rem;
-  }
-  
-  .stat-icon {
-    font-size: 2.5rem;
-  }
-  
-  .quick-action-card {
-    flex-direction: column;
-    text-align: center;
-    gap: 1rem;
-  }
-  
-  .action-icon {
-    font-size: 2rem;
-  }
-}
-
-
-

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,150 +1,124 @@
-﻿import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
-import { fetchEstudantes } from '../redux/slices/estudantesSlice';
-import { fetchEmpresas } from '../redux/slices/empresasSlice';
-import { fetchFuncionarios } from '../redux/slices/funcionariosSlice';
-import { fetchAvaliacoes } from '../redux/slices/avaliacoesSlice';
-import RelacionamentosOverview from './RelacionamentosOverview';
+import api from '../services/api';
 import './Dashboard.css';
-import './RelacionamentosOverview.css';
-const Dashboard = () => {
-  const dispatch = useDispatch();
 
-  const { items: estudantes, status: estudantesStatus } = useSelector((state) => state.estudantes);
-  const { items: empresas, status: empresasStatus } = useSelector((state) => state.empresas);
-  const { items: funcionarios, status: funcionariosStatus } = useSelector((state) => state.funcionarios);
-  const { items: avaliacoes, status: avaliacoesStatus } = useSelector((state) => state.avaliacoes);
+const Dashboard = () => {
+  const [overview, setOverview] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    if (estudantesStatus === 'idle') dispatch(fetchEstudantes());
-    if (empresasStatus === 'idle') dispatch(fetchEmpresas());
-    if (funcionariosStatus === 'idle') dispatch(fetchFuncionarios());
-    if (avaliacoesStatus === 'idle') dispatch(fetchAvaliacoes());
-  }, [dispatch, estudantesStatus, empresasStatus, funcionariosStatus, avaliacoesStatus]);
+    const loadOverview = async () => {
+      try {
+        setLoading(true);
+        const response = await api.get('/dashboard');
+        setOverview(response.data);
+      } catch (err) {
+        setError('Não foi possível carregar o dashboard agora.');
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  const stats = [
-    {
-      title: 'Estudantes cadastrados',
-      value: estudantes.length,
-      icon: 'ES',
-      color: 'blue',
-      description: 'Registros carregados da API de estudantes',
-    },
-    {
-      title: 'Empresas inclusivas',
-      value: empresas.length,
-      icon: 'EM',
-      color: 'green',
-      description: 'Registros carregados da API de empresas',
-    },
-    {
-      title: 'Funcionarios de apoio',
-      value: funcionarios.length,
-      icon: 'FN',
-      color: 'purple',
-      description: 'Registros carregados da API de funcionarios',
-    },
-    {
-      title: 'Avaliacoes realizadas',
-      value: avaliacoes.length,
-      icon: 'AV',
-      color: 'orange',
-      description: 'Registros carregados da API de avaliacoes',
-    },
-  ];
+    loadOverview();
+  }, []);
+
+  const resumo = overview?.resumo || {};
+
+  const statCards = useMemo(() => ([
+    { title: 'Estudantes', value: resumo.estudantes || 0, color: 'blue', hint: 'Pessoas acompanhadas' },
+    { title: 'Empresas', value: resumo.empresas || 0, color: 'green', hint: 'Parceiras ativas' },
+    { title: 'Avaliações', value: resumo.avaliacoes || 0, color: 'orange', hint: 'Registros aplicados' },
+    { title: 'Fichas', value: resumo.fichasAcompanhamento || 0, color: 'purple', hint: 'Acompanhamentos ativos' },
+    { title: 'Enc. Ativos', value: resumo.encaminhamentosAtivos || 0, color: 'teal', hint: 'Em andamento' },
+    { title: 'Enc. Desligados', value: resumo.encaminhamentosDesligados || 0, color: 'red', hint: 'Ciclos encerrados' },
+  ]), [resumo]);
 
   const quickActions = [
-    { title: 'Cadastrar estudante', description: 'Registrar novo estudante no sistema', icon: 'ES', link: '/novo-estudante', color: 'blue' },
-    { title: 'Cadastrar empresa', description: 'Registrar nova empresa parceira', icon: 'EM', link: '/nova-empresa', color: 'green' },
-    { title: 'Cadastrar funcionario', description: 'Registrar colaborador de apoio', icon: 'FN', link: '/novo-funcionario', color: 'purple' },
-    { title: 'Nova avaliacao', description: 'Iniciar uma avaliacao de desempenho', icon: 'AV', link: '/avaliacoes', color: 'orange' },
-    { title: 'Relacionar estudante e empresa', description: 'Criar vinculos de encaminhamento', icon: 'RL', link: '/relacionamentos', color: 'teal' },
-  ];
-
-  const recentActivities = [
-    { action: 'Estudante cadastrado', user: 'Cadastro ativo', time: 'agora', type: 'success' },
-    { action: 'Empresa atualizada', user: 'Cadastro ativo', time: 'agora', type: 'info' },
-    { action: 'Avaliacao registrada', user: 'Fluxo em uso', time: 'agora', type: 'success' },
-  ];
-
-  const resources = [
-    { title: 'Guia de estudos', description: 'Metodos de ensino adaptados' },
-    { title: 'Roteiro de entrevista', description: 'Boas praticas para selecao' },
-    { title: 'Plano de habilidades', description: 'Evolucao tecnica e comportamental' },
-    { title: 'Suporte familiar', description: 'Orientacoes de acompanhamento' },
+    { title: 'Nova ficha', link: '/relacionamentos', icon: 'FC' },
+    { title: 'Novo encaminhamento', link: '/relacionamentos', icon: 'EN' },
+    { title: 'Nova avaliação', link: '/avaliacoes', icon: 'AV' },
+    { title: 'Empresas', link: '/empresas', icon: 'EM' },
   ];
 
   return (
-    <div className="dashboard">
-      <div className="dashboard-header">
-        <h1>Instituto de Educacao Especial Diomicio Freitas</h1>
-        <p>Conectando pessoas autistas com oportunidades de educacao e trabalho</p>
+    <div className="dashboard-v2">
+      <div className="dashboard-v2-header">
+        <div>
+          <p className="dashboard-v2-tag">Aba exclusiva de gestão</p>
+          <h1>Dashboard de acompanhamento</h1>
+          <p className="dashboard-v2-subtitle">
+            Visão completa de estudantes, empresas, fichas e encaminhamentos em um só lugar.
+          </p>
+        </div>
+        <Link to="/relacionamentos" className="dashboard-v2-cta">Criar encaminhamento</Link>
       </div>
 
-      <div className="stats-grid">
-        {stats.map((stat) => (
-          <div key={stat.title} className={`stat-card ${stat.color}`}>
-            <div className="stat-icon">{stat.icon}</div>
-            <div className="stat-content">
-              <h3 className="stat-title">{stat.title}</h3>
-              <div className="stat-value">{stat.value}</div>
-              <div className="stat-description">{stat.description}</div>
+      {loading && <div className="dashboard-v2-feedback">Carregando dados do painel...</div>}
+      {error && !loading && <div className="dashboard-v2-feedback error">{error}</div>}
+
+      {!loading && !error && (
+        <>
+          <div className="dashboard-v2-stats">
+            {statCards.map((stat) => (
+              <article key={stat.title} className={`dash-card ${stat.color}`}>
+                <span>{stat.title}</span>
+                <strong>{stat.value}</strong>
+                <small>{stat.hint}</small>
+              </article>
+            ))}
+          </div>
+
+          <div className="dashboard-v2-grid">
+            <section className="dash-panel">
+              <header>
+                <h2>Encaminhamentos recentes</h2>
+              </header>
+              <div className="timeline-list">
+                {(overview?.encaminhamentosRecentes || []).map((item) => (
+                  <div key={item.id} className="timeline-item">
+                    <p>Empresa: {item.empresaId}</p>
+                    <span>Status: {item.status}</span>
+                  </div>
+                ))}
+                {!overview?.encaminhamentosRecentes?.length && <p>Nenhum encaminhamento recente.</p>}
+              </div>
+            </section>
+
+            <section className="dash-panel">
+              <header>
+                <h2>Fichas recentes</h2>
+              </header>
+              <div className="timeline-list">
+                {(overview?.fichasRecentes || []).map((item) => (
+                  <div key={item.id} className="timeline-item">
+                    <p>{item.descricao}</p>
+                    <span>Status: {item.status}</span>
+                  </div>
+                ))}
+                {!overview?.fichasRecentes?.length && <p>Nenhuma ficha recente.</p>}
+              </div>
+            </section>
+          </div>
+
+          <section className="dash-panel actions">
+            <header>
+              <h2>Ações rápidas</h2>
+            </header>
+            <div className="quick-grid">
+              {quickActions.map((action) => (
+                <Link to={action.link} key={action.title} className="quick-card">
+                  <span>{action.icon}</span>
+                  <div>
+                    <h3>{action.title}</h3>
+                  </div>
+                </Link>
+              ))}
             </div>
-          </div>
-        ))}
-      </div>
-      <RelacionamentosOverview />
-      <div className="dashboard-content">
-        <div className="dashboard-section">
-          <h2>Acoes rapidas</h2>
-          <div className="quick-actions-grid">
-            {quickActions.map((action) => (
-              <Link key={action.title} to={action.link} className={`quick-action-card ${action.color}`}>
-                <div className="action-icon">{action.icon}</div>
-                <div className="action-content">
-                  <h3>{action.title}</h3>
-                  <p>{action.description}</p>
-                </div>
-                <div className="action-arrow">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-                    <path d="M5 12H19M19 12L12 5M19 12L12 19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                  </svg>
-                </div>
-              </Link>
-            ))}
-          </div>
-        </div>
-
-        <div className="dashboard-section">
-          <h2>Recursos de apoio</h2>
-          <div className="resources-grid">
-            {resources.map((resource) => (
-              <div key={resource.title} className="resource-card">
-                <div className="resource-content">
-                  <h3>{resource.title}</h3>
-                  <p>{resource.description}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div className="dashboard-section">
-          <h2>Atividades recentes</h2>
-          <div className="activities-list">
-            {recentActivities.map((activity) => (
-              <div key={`${activity.action}-${activity.type}`} className={`activity-item ${activity.type}`}>
-                <div className="activity-content">
-                  <div className="activity-action">{activity.action}</div>
-                  <div className="activity-user">{activity.user}</div>
-                </div>
-                <div className="activity-time">{activity.time}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+          </section>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,6 +8,7 @@ const Header = ({ user, onLogout }) => {
 
   const menuItems = [
     { path: '/', label: 'Inicio', icon: 'IN' },
+    { path: '/dashboard', label: 'Dashboard', icon: 'DB' },
     { path: '/cadastroAlunos', label: 'Estudantes', icon: 'ES' },
     { path: '/avaliacoes', label: 'Avaliacoes', icon: 'AV' },
     { path: '/empresas', label: 'Empresas', icon: 'EM' },

--- a/src/components/Home.css
+++ b/src/components/Home.css
@@ -1,0 +1,96 @@
+.home-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.home-hero {
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.95), rgba(37, 99, 235, 0.85));
+  color: #fff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 45px rgba(30, 64, 175, 0.25);
+}
+
+.home-badge {
+  display: inline-flex;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.home-hero h1 {
+  margin: 1rem 0 0.75rem;
+  font-size: clamp(1.8rem, 4vw, 2.7rem);
+}
+
+.home-hero p {
+  margin: 0;
+  max-width: 700px;
+  opacity: 0.95;
+}
+
+.home-hero-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.home-btn {
+  border-radius: 12px;
+  padding: 0.7rem 1rem;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.home-btn.primary {
+  color: #1e3a8a;
+  background: #fff;
+}
+
+.home-btn.secondary {
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+}
+
+.home-shortcuts {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.shortcut-card {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 1.2rem;
+  text-decoration: none;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  transition: transform 0.2s ease;
+}
+
+.shortcut-card:hover {
+  transform: translateY(-4px);
+}
+
+.shortcut-card span {
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.shortcut-card h3 {
+  margin: 0.5rem 0;
+  color: var(--text);
+}
+
+.shortcut-card p {
+  margin: 0;
+  color: var(--text-light);
+  font-size: 0.9rem;
+}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom';
+import './Home.css';
+
+const Home = () => {
+  const shortcuts = [
+    {
+      title: 'Dashboard Inteligente',
+      description: 'Acompanhe métricas, encaminhamentos e evolução em uma aba dedicada.',
+      to: '/dashboard',
+      tag: 'Novo',
+    },
+    {
+      title: 'Gestão de Estudantes',
+      description: 'Cadastre, edite e acompanhe estudantes em poucos cliques.',
+      to: '/cadastroAlunos',
+      tag: 'Operação',
+    },
+    {
+      title: 'Rede de Empresas',
+      description: 'Fortaleça parcerias e acompanhe oportunidades de inclusão.',
+      to: '/empresas',
+      tag: 'Parcerias',
+    },
+  ];
+
+  return (
+    <section className="home-page">
+      <div className="home-hero">
+        <p className="home-badge">Plataforma Diomício Freitas</p>
+        <h1>Central de gestão e inclusão profissional</h1>
+        <p>
+          Organize estudantes, empresas, encaminhamentos e avaliações com mais clareza.
+          Agora o dashboard fica em uma aba exclusiva para análise completa.
+        </p>
+        <div className="home-hero-actions">
+          <Link to="/dashboard" className="home-btn primary">Abrir dashboard</Link>
+          <Link to="/relacionamentos" className="home-btn secondary">Criar relacionamento</Link>
+        </div>
+      </div>
+
+      <div className="home-shortcuts">
+        {shortcuts.map((item) => (
+          <Link key={item.title} to={item.to} className="shortcut-card">
+            <span>{item.tag}</span>
+            <h3>{item.title}</h3>
+            <p>{item.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
### Motivation
- Introduce follow-up records and referrals to support case management by adding `fichas_acompanhamento` and `encaminhamentos` concepts and endpoints. 
- Provide an aggregated management view by adding a `dashboard` endpoint that summarizes counts and recent records. 
- Improve UX by adding a new `Home` page and redesigning the frontend `Dashboard` with a refreshed layout and styles.

### Description
- Backend: added entities `FichaAcompanhamento` and `Encaminhamento`, DTOs, services, controllers and modules under `modules/fichas` and `modules/encaminhamentos`, plus a new `dashboard` module with `DashboardService` and `DashboardController` that aggregate counts and recent items; registered these modules in `AppModule`.
- Database: added migration `1760000003000-AddFichasEEncaminhamentos.ts` to create `fichas_acompanhamento` and `encaminhamentos` tables and related indexes and foreign keys.
- Frontend: introduced `Home` component and styles, updated routing in `src/App.jsx` to make `Home` the root and expose `/dashboard`, rewrote `src/components/Dashboard.jsx` to fetch `/dashboard` via `api`, removed previous Redux-only dependency for dashboard data, and updated `Header` to include the `Dashboard` menu item.
- UI/Assets: large CSS refactor for the dashboard in `src/components/Dashboard.css` (new class names and layout), plus new `Home.css`; updated Postman collection `backend/postman/ONG.postman_collection.json` with `Fichas`, `Encaminhamentos`, `Dashboard` requests and collection variables `fichaId`/`encaminhamentoId` for test flows.

### Testing
- No automated tests were added or executed as part of this change.
- The change includes a migration and new API endpoints which should be validated by running the existing test suite and applying the migration before deploying.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3a097b58832c9e1cdd98aa32af78)