### PR TITLE
docs: add 'Manual do Usuário' and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Aplicacao full stack para cadastro e acompanhamento de estudantes, empresas, fun
 - Backend: NestJS, TypeORM, PostgreSQL
 - Testes: Vitest no frontend e Node test runner no backend
 
+
+## Documentação
+
+- [Manual do Usuário](docs/MANUAL_USUARIO.md): guia de uso do sistema com instruções sobre login, cadastros, avaliações, encaminhamentos, dashboard e FAQ.
+
 ## Como rodar
 
 ### 1. Frontend

--- a/docs/MANUAL_USUARIO.md
+++ b/docs/MANUAL_USUARIO.md
@@ -1,0 +1,221 @@
+# Manual do Usuário — Sistema Diomício Freitas
+
+## Introdução
+
+Este manual orienta o usuário no uso do Sistema Diomício Freitas, uma aplicação criada para apoiar a gestão de estudantes, empresas parceiras, avaliações, encaminhamentos e indicadores do projeto.
+
+O sistema possui acesso restrito por login e apresenta um menu principal com atalhos para as áreas mais utilizadas: **Início**, **Dashboard**, **Estudantes**, **Avaliações**, **Empresas**, **Funcionários** e **Relações**.
+
+### Objetivo do sistema
+
+O objetivo do sistema é centralizar informações importantes da rotina administrativa, facilitando:
+
+- o cadastro e a consulta de alunos;
+- o cadastro e a consulta de empresas parceiras;
+- o registro de avaliações;
+- o acompanhamento de encaminhamentos e relações entre estudantes e empresas;
+- a visualização de indicadores no dashboard.
+
+### Recomendações gerais de uso
+
+- Mantenha os dados dos alunos e empresas sempre atualizados.
+- Confira as informações antes de salvar cadastros, avaliações ou encaminhamentos.
+- Use o botão **Sair** ao finalizar o uso do sistema, principalmente em computadores compartilhados.
+- Caso encontre uma mensagem de erro, revise os campos obrigatórios e tente novamente.
+
+## Tela de login
+
+A tela de login é exibida ao abrir o sistema quando o usuário ainda não está autenticado.
+
+### Como acessar
+
+1. Abra o endereço do sistema no navegador.
+2. Aguarde o carregamento inicial.
+3. Na tela **Acesso restrito**, informe seu login e sua senha.
+4. Clique em **Entrar no Portal**.
+
+### Campos da tela
+
+| Campo | Descrição |
+| --- | --- |
+| Login | Nome de usuário utilizado para acessar o sistema. |
+| Senha | Senha cadastrada para o usuário. |
+
+### Mensagens comuns
+
+- **Login ou senha inválidos**: revise as credenciais digitadas e tente novamente.
+- **Validando...**: indica que o sistema está conferindo os dados de acesso.
+
+### Sair do sistema
+
+Para encerrar a sessão, clique no botão **Sair**, localizado no canto superior direito do sistema. Em telas menores, abra o menu mobile para localizar a opção.
+
+## Cadastro de alunos
+
+A área de alunos permite consultar, cadastrar e editar estudantes atendidos pelo projeto.
+
+### Acessar a lista de alunos
+
+1. Após fazer login, clique em **Estudantes** no menu principal.
+2. O sistema exibirá a listagem de alunos cadastrados.
+3. Use a listagem para localizar registros existentes ou iniciar um novo cadastro.
+
+### Cadastrar novo aluno
+
+1. Na área **Estudantes**, clique na opção de novo cadastro, quando disponível.
+2. Preencha os dados solicitados no formulário.
+3. Revise as informações inseridas.
+4. Clique no botão de salvar/cadastrar.
+
+### Editar aluno
+
+1. Acesse **Estudantes**.
+2. Localize o aluno desejado na lista.
+3. Selecione a opção de edição.
+4. Atualize os dados necessários.
+5. Salve as alterações.
+
+### Boas práticas
+
+- Cadastre o nome completo do aluno.
+- Verifique documentos, contatos e demais dados antes de salvar.
+- Atualize o cadastro sempre que houver mudança de telefone, endereço, situação ou informações relevantes.
+
+## Cadastro de empresas
+
+A área de empresas permite gerenciar empresas parceiras que podem receber estudantes encaminhados pelo projeto.
+
+### Acessar a lista de empresas
+
+1. Clique em **Empresas** no menu principal.
+2. O sistema exibirá as empresas cadastradas.
+3. Consulte a lista antes de cadastrar uma nova empresa, evitando duplicidade.
+
+### Cadastrar nova empresa
+
+1. Na área **Empresas**, clique na opção de nova empresa, quando disponível.
+2. Preencha os dados solicitados, como nome, CNPJ e informações de contato.
+3. Revise todos os campos.
+4. Salve o cadastro.
+
+### Editar empresa
+
+1. Acesse **Empresas**.
+2. Localize a empresa desejada.
+3. Selecione a opção de edição.
+4. Atualize os dados necessários.
+5. Salve as alterações.
+
+### Boas práticas
+
+- Confira o CNPJ antes de salvar.
+- Mantenha dados de contato atualizados para facilitar comunicações futuras.
+- Registre informações que ajudem no acompanhamento dos encaminhamentos.
+
+## Avaliações
+
+A área de avaliações é usada para registrar e consultar avaliações relacionadas aos alunos.
+
+### Acessar avaliações
+
+1. Clique em **Avaliações** no menu principal.
+2. Consulte a lista de avaliações registradas.
+3. Se necessário, abra uma avaliação existente ou inicie um novo registro.
+
+### Registrar avaliação
+
+1. Acesse a tela de avaliação.
+2. Selecione ou informe o aluno avaliado, conforme o fluxo disponível.
+3. Preencha os dados solicitados, como tipo de avaliação, professor responsável e respostas do formulário.
+4. Revise as respostas.
+5. Salve a avaliação.
+
+### Consulta e acompanhamento
+
+Use a listagem de avaliações para acompanhar o histórico dos alunos e identificar informações importantes para decisões pedagógicas, administrativas ou de encaminhamento.
+
+### Boas práticas
+
+- Preencha a avaliação com atenção e de forma objetiva.
+- Evite deixar campos obrigatórios em branco.
+- Revise o aluno selecionado antes de salvar.
+
+## Encaminhamentos
+
+Os encaminhamentos representam o vínculo ou direcionamento de alunos para empresas parceiras.
+
+No sistema, esse fluxo pode aparecer na área **Relações**, responsável por relacionar estudantes e empresas.
+
+### Criar encaminhamento ou relação
+
+1. Clique em **Relações** no menu principal.
+2. Selecione o estudante que será encaminhado.
+3. Selecione a empresa parceira.
+4. Preencha as informações adicionais solicitadas, quando houver.
+5. Salve o relacionamento ou encaminhamento.
+
+### Acompanhar encaminhamentos
+
+1. Acesse **Relações**.
+2. Consulte os vínculos existentes entre estudantes e empresas.
+3. Verifique a situação de cada relação, quando o status estiver disponível.
+
+### Boas práticas
+
+- Confirme se o aluno e a empresa selecionados estão corretos.
+- Atualize a situação do encaminhamento sempre que houver mudança.
+- Evite criar relações duplicadas para o mesmo aluno e a mesma empresa.
+
+## Dashboard
+
+O dashboard apresenta uma visão geral dos dados do sistema, facilitando o acompanhamento de indicadores.
+
+### Acessar o dashboard
+
+1. Clique em **Dashboard** no menu principal.
+2. Aguarde o carregamento dos indicadores.
+3. Analise os cards, gráficos ou resumos disponíveis.
+
+### Como interpretar
+
+Os indicadores podem ajudar a acompanhar informações como quantidade de alunos, empresas, avaliações e encaminhamentos. Use esses dados para ter uma visão rápida da situação atual do projeto.
+
+### Boas práticas
+
+- Consulte o dashboard regularmente.
+- Verifique se os cadastros estão atualizados caso algum indicador pareça incorreto.
+- Use os números como apoio para planejamento e tomada de decisão.
+
+## FAQ
+
+### 1. Não consigo entrar no sistema. O que devo fazer?
+
+Confira se o login e a senha foram digitados corretamente. Se o problema continuar, procure o responsável técnico ou administrativo pelo sistema.
+
+### 2. Esqueci minha senha. Como recuperar?
+
+Use a opção **Esqueci minha senha**, se estiver disponível e configurada. Caso contrário, solicite suporte ao administrador do sistema.
+
+### 3. Cadastrei um aluno com informação errada. Posso corrigir?
+
+Sim. Acesse **Estudantes**, localize o aluno, entre na opção de edição e salve os dados corrigidos.
+
+### 4. Cadastrei uma empresa duplicada. O que fazer?
+
+Verifique qual cadastro está mais completo e solicite a correção ou remoção do registro duplicado ao responsável pelo sistema, se a exclusão não estiver disponível para seu perfil.
+
+### 5. Uma avaliação pode ser alterada depois de salva?
+
+Depende das permissões e regras configuradas no sistema. Caso a edição não esteja disponível, entre em contato com o responsável administrativo.
+
+### 6. Como relacionar um aluno a uma empresa?
+
+Acesse **Relações**, selecione o aluno, escolha a empresa parceira e salve o vínculo.
+
+### 7. Os dados do dashboard parecem incorretos. O que verificar?
+
+Confira se os cadastros de alunos, empresas, avaliações e encaminhamentos estão completos e atualizados. Depois, atualize a página e consulte o dashboard novamente.
+
+### 8. Posso usar o sistema no celular?
+
+Sim. O sistema possui menu adaptado para telas menores. Em celulares, use o botão de menu para acessar as áreas principais.


### PR DESCRIPTION
### Motivation
- Provide a simple user-facing manual that documents main workflows (login, student and company registration, evaluations, encaminhamentos, dashboard and FAQ) and make it discoverable from the project README.

### Description
- Add `docs/MANUAL_USUARIO.md` containing the user manual with sections for Introdução, Tela de login, Cadastro de alunos, Cadastro de empresas, Avaliações, Encaminhamentos, Dashboard and FAQ.
- Update `README.md` to add a `Documentação` section linking to `docs/MANUAL_USUARIO.md`.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc726de7c832cb4646ab5da2bea8f)